### PR TITLE
Add nuget.config to force feed usage

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+  Workaround for intermittent issue
+  https://developercommunity.visualstudio.com/content/problem/983843/dotnet-build-task-does-not-use-nugetorg-for-one-pr.html
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Reportedly, there's an intermittent issue with package restoration. This PR adds a `nuget.config` to ensure we only use the nuget public feed as our package oracle. For more information, see https://developercommunity.visualstudio.com/content/problem/983843/dotnet-build-task-does-not-use-nugetorg-for-one-pr.html