### PR TITLE
Fix local paths for AppX packages

### DIFF
--- a/src/CompDB.Shared/CompDB.cs
+++ b/src/CompDB.Shared/CompDB.cs
@@ -66,6 +66,13 @@ namespace CompDB
             public List<Package> Package { get; set; }
         }
 
+        [XmlRoot(ElementName = "AppX", Namespace = "http://schemas.microsoft.com/embedded/2004/10/ImageUpdate")]
+        public class AppX
+        {
+            [XmlElement(ElementName = "AppXPackages", Namespace = "http://schemas.microsoft.com/embedded/2004/10/ImageUpdate")]
+            public Packages AppXPackages { get; set; }
+        }
+
         [XmlRoot(ElementName = "Features", Namespace = "http://schemas.microsoft.com/embedded/2004/10/ImageUpdate")]
         public class Features
         {
@@ -129,6 +136,12 @@ namespace CompDB
 
             [XmlElement(ElementName = "Packages", Namespace = "http://schemas.microsoft.com/embedded/2004/10/ImageUpdate")]
             public Packages Packages { get; set; }
+
+            [XmlElement(ElementName = "AppX", Namespace = "http://schemas.microsoft.com/embedded/2004/10/ImageUpdate")]
+            public AppX AppX { get; set; }
+
+            [XmlElement(ElementName = "AppXPackages", Namespace = "http://schemas.microsoft.com/embedded/2004/10/ImageUpdate")]
+            public Packages AppXPackages { get; set; }
 
             [XmlAttribute(AttributeName = "xsi", Namespace = "http://www.w3.org/2000/xmlns/")]
             public string Xsi { get; set; }

--- a/src/UUPDownload/Program.cs
+++ b/src/UUPDownload/Program.cs
@@ -262,6 +262,10 @@ namespace UUPDownload
                     {
                         payloadItems.Add(pkg.Payload.PayloadItem);
                     }
+
+                    if (cdb.AppX != null)
+                        foreach (CompDBXmlClass.Package pkg in cdb.AppX.AppXPackages.Package)
+                            payloadItems.Add(pkg.Payload.PayloadItem);
                 }
             }
 


### PR DESCRIPTION
Use CompDB provided paths for AppX files instead of flattened ones from WU extended metadata