### PR TITLE
Add Project reference to UUPMediaConverterDismBroker

### DIFF
--- a/src/Applications/UUPMediaConverterCli/UUPMediaConverterCli.csproj
+++ b/src/Applications/UUPMediaConverterCli/UUPMediaConverterCli.csproj
@@ -14,5 +14,8 @@
     <ProjectReference Include="..\..\InterCommunication.NET\InterCommunication.NET.csproj" />
     <ProjectReference Include="..\..\MediaCreationLib.NET\MediaCreationLib.NET.csproj" />
     <ProjectReference Include="..\..\Cabinet.NET\Cabinet.NET.csproj" />
+    <ProjectReference Include="..\UUPMediaConverterDismBroker\UUPMediaConverterDismBroker.csproj">
+      <Private>True</Private>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add a Project reference to UUPMediaConverterDismBroker so it does not have to be copied seperately