### PR TITLE
Support for bulk adding files to WIMs

### DIFF
--- a/src/UnifiedUpdatePlatform.Imaging.NET/IImaging.cs
+++ b/src/UnifiedUpdatePlatform.Imaging.NET/IImaging.cs
@@ -30,6 +30,8 @@ namespace UnifiedUpdatePlatform.Imaging.NET
 
         public bool AddFileToImage(string wimFile, int imageIndex, string fileToAdd, string destination, ProgressCallback progressCallback = null);
 
+        public bool AddFilesToImage(string wimFile, int imageIndex, IEnumerable<(string fileToAdd, string destination)> fileList, ProgressCallback progressCallback = null);
+
         public bool DeleteFileFromImage(string wimFile, int imageIndex, string fileToRemove, ProgressCallback progressCallback = null);
 
         public bool ExportImage(string wimFile, string destinationWimFile, int imageIndex, IEnumerable<string> referenceWIMs = null, WimCompressionType compressionType = WimCompressionType.Lzx, ProgressCallback progressCallback = null);

--- a/src/UnifiedUpdatePlatform.Imaging.NET/Properties/AssemblyInfo.cs
+++ b/src/UnifiedUpdatePlatform.Imaging.NET/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.5.0")]
-[assembly: AssemblyFileVersion("3.1.5.0")]
+[assembly: AssemblyVersion("3.1.6.0")]
+[assembly: AssemblyFileVersion("3.1.6.0")]

--- a/src/UnifiedUpdatePlatform.Imaging.NET/WIMImaging.cs
+++ b/src/UnifiedUpdatePlatform.Imaging.NET/WIMImaging.cs
@@ -13,6 +13,11 @@ namespace UnifiedUpdatePlatform.Imaging.NET
             return WimgApi.AddFileToImage(wimFile, imageIndex, fileToAdd, destination, progressCallback) || WimLib.AddFileToImage(wimFile, imageIndex, fileToAdd, destination, progressCallback);
         }
 
+        public bool AddFilesToImage(string wimFile, int imageIndex, IEnumerable<(string fileToAdd, string destination)> fileList, IImaging.ProgressCallback progressCallback = null)
+        {
+            return WimgApi.AddFilesToImage(wimFile, imageIndex, fileList, progressCallback) || WimLib.AddFilesToImage(wimFile, imageIndex, fileList, progressCallback);
+        }
+
         public bool ApplyImage(string wimFile, int imageIndex, string OutputDirectory, IEnumerable<string> referenceWIMs = null, bool PreserveACL = true, IImaging.ProgressCallback progressCallback = null)
         {
             return WimgApi.ApplyImage(wimFile, imageIndex, OutputDirectory, referenceWIMs, PreserveACL, progressCallback) || WimLib.ApplyImage(wimFile, imageIndex, OutputDirectory, referenceWIMs, PreserveACL, progressCallback);

--- a/src/UnifiedUpdatePlatform.Imaging.NET/WimgApiImaging.cs
+++ b/src/UnifiedUpdatePlatform.Imaging.NET/WimgApiImaging.cs
@@ -14,6 +14,11 @@ namespace UnifiedUpdatePlatform.Imaging.NET
             return false;
         }
 
+        public bool AddFilesToImage(string wimFile, int imageIndex, IEnumerable<(string fileToAdd, string destination)> fileList, IImaging.ProgressCallback progressCallback = null)
+        {
+            return false;
+        }
+
         public bool DeleteFileFromImage(string wimFile, int imageIndex, string fileToRemove, IImaging.ProgressCallback progressCallback = null)
         {
             return false;

--- a/src/UnifiedUpdatePlatform.Media.Creator.NET/Installer/WindowsInstallerBuilder.cs
+++ b/src/UnifiedUpdatePlatform.Media.Creator.NET/Installer/WindowsInstallerBuilder.cs
@@ -328,6 +328,7 @@ namespace UnifiedUpdatePlatform.Media.Creator.NET.Installer
             }
             string langcode = dirs.First().Replace(Path.Combine(MediaPath, "sources") + Path.DirectorySeparatorChar, "");
 
+            var finalSetupFileList = new List<(string fileToAdd, string destination)>();
             foreach (string file in IniReader.SetupFilesToBackport)
             {
                 progressCallback?.Log($"Processing {file}");
@@ -343,17 +344,14 @@ namespace UnifiedUpdatePlatform.Media.Creator.NET.Installer
                 {
                     progressCallback?.Log($"Found {matchingfile}");
 
-                    result = Constants.imagingInterface.AddFileToImage(bootwim, 2, sourcePath, normalizedPath, progressCallback: progressCallback?.GetImagingCallback());
-                    if (!result)
-                    {
-                        goto exit;
-                    }
+                    finalSetupFileList.Add((sourcePath, normalizedPath));
                 }
                 else
                 {
                     progressCallback?.Log($"Didn't find {matchingfile}");
                 }
             }
+            result = Constants.imagingInterface.AddFilesToImage(bootwim, 2, finalSetupFileList, progressCallback: progressCallback?.GetImagingCallback());
 
         exit:
             return result;


### PR DESCRIPTION
Image builder now adds offline setup files to boot.wim in one batch instead of calling WimLib individually for every entry.

Knocks down that part of the build process from ~1s per file (~2min as of build 23451) to ~1s per whole batch.

Not sure if this follows ideal versioning practices, open to feedback.