### PR TITLE
More WIM update batching, in-place PE export

### DIFF
--- a/src/Applications/UUPMediaConverter/Properties/AssemblyInfo.cs
+++ b/src/Applications/UUPMediaConverter/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright © Gustave Monce and Contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("3.1.5.0")]
-[assembly: AssemblyFileVersion("3.1.5.0")]
+[assembly: AssemblyVersion("3.1.6.1")]
+[assembly: AssemblyFileVersion("3.1.6.1")]

--- a/src/UnifiedUpdatePlatform.Imaging.NET/Properties/AssemblyInfo.cs
+++ b/src/UnifiedUpdatePlatform.Imaging.NET/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.6.0")]
-[assembly: AssemblyFileVersion("3.1.6.0")]
+[assembly: AssemblyVersion("3.1.6.1")]
+[assembly: AssemblyFileVersion("3.1.6.1")]

--- a/src/UnifiedUpdatePlatform.Media.Creator.NET/Properties/AssemblyInfo.cs
+++ b/src/UnifiedUpdatePlatform.Media.Creator.NET/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.5.0")]
-[assembly: AssemblyFileVersion("3.1.5.0")]
+[assembly: AssemblyVersion("3.1.6.1")]
+[assembly: AssemblyFileVersion("3.1.6.1")]


### PR DESCRIPTION
- all WIM content add and delete ops are batched if possible
- add and delete ops now call a common update function
- boot.wim index duplication no longer uses a temp file
- fixed progress reporting for Feature Package recompression
- toned down progress reporting when locating setup files
- version bumped to 3.1.6.1 for relevant converter parts