### PR TITLE
Validate temporary path before use

### DIFF
--- a/src/TempManager/TempManager.cs
+++ b/src/TempManager/TempManager.cs
@@ -33,11 +33,16 @@ namespace UnifiedUpdatePlatform.Services.Temp
 
         }
 
-        public TempManager(string Temp)
+        public TempManager(string temp)
         {
-            if (!string.IsNullOrEmpty(Temp))
+            if (!string.IsNullOrEmpty(temp))
             {
-                this.Temp = Temp;
+                Temp = temp;
+            }
+
+            if (!Directory.Exists(Temp))
+            {
+                throw new DirectoryNotFoundException("The specified temporary directory cannot be accessed or does not exist.");
             }
         }
 


### PR DESCRIPTION
Catches typos/errors earlier during media creation workflow. Without this in place, the temporary path doesn't get validated, aggregated metadata extraction fails, and ambiguous composition database errors surface.