### PR TITLE
Fix "Index was outside the bounds of the array" error

### DIFF
--- a/src/UnifiedUpdatePlatform.Services.WindowsUpdate.Downloads/DownloadHelpers.cs
+++ b/src/UnifiedUpdatePlatform.Services.WindowsUpdate.Downloads/DownloadHelpers.cs
@@ -568,17 +568,23 @@ namespace UnifiedUpdatePlatform.Services.WindowsUpdate.Downloads
                         }
                         catch { }
 
-                        uint i = 1;
-                        while (!pathList.Add(newPath.ToLower()))
+                        if (!pathList.Add(newPath.ToLower()))
                         {
+                            string basePath, suffix;
                             if (Path.HasExtension(newPath))
                             {
-                                newPath = Path.Combine(Path.GetDirectoryName(newPath), Path.GetFileNameWithoutExtension(newPath) + $" ({i++})" + Path.GetExtension(newPath));
+                                basePath = Path.Combine(Path.GetDirectoryName(newPath), Path.GetFileNameWithoutExtension(newPath));
+                                suffix = Path.GetExtension(newPath);
                             }
                             else
                             {
-                                newPath = Path.Combine(Path.GetDirectoryName(newPath), Path.GetFileName(newPath) + $" ({i++})");
+                                basePath = Path.Combine(Path.GetDirectoryName(newPath), Path.GetFileName(newPath));
+                                suffix = "";
                             }
+
+                            uint i = 1;
+                            while (!pathList.Add(newPath.ToLower()))
+                                newPath = basePath + $" ({i++})" + suffix;
                         }
 
                         fileList.Add(new UUPFile(

--- a/src/UnifiedUpdatePlatform.Services.WindowsUpdate.Downloads/DownloadHelpers.cs
+++ b/src/UnifiedUpdatePlatform.Services.WindowsUpdate.Downloads/DownloadHelpers.cs
@@ -571,7 +571,7 @@ namespace UnifiedUpdatePlatform.Services.WindowsUpdate.Downloads
                         uint i = 1;
                         while (!pathList.Add(newPath.ToLower()))
                         {
-                            if (newPath.Split("\\")[^0].Contains('.'))
+                            if (Path.HasExtension(newPath))
                             {
                                 newPath = Path.Combine(Path.GetDirectoryName(newPath), Path.GetFileNameWithoutExtension(newPath) + $" ({i++})" + Path.GetExtension(newPath));
                             }


### PR DESCRIPTION
[^0] will try to access non-existing item in the split newPath array. Use [^1] instead to access the last part of the file name.