### PR TITLE
Update LocateFilesForSetupMediaCreation to include edition parameter for Base Edition matching

### DIFF
--- a/src/UnifiedUpdatePlatform.Media.Creator/FileLocator.cs
+++ b/src/UnifiedUpdatePlatform.Media.Creator/FileLocator.cs
@@ -96,9 +96,39 @@ namespace UnifiedUpdatePlatform.Media.Creator
             string UUPPath,
             string LanguageCode,
             IEnumerable<CompDB> CompositionDatabases,
-            ProgressCallback? progressCallback = null)
+            ProgressCallback? progressCallback = null,
+            string edition = null)
         {
             progressCallback?.Invoke(Common.Messaging.Common.ProcessPhase.ReadingMetadata, true, 0, "Looking up Composition Database in order to find a Base ESD image appropriate for building windows setup files.");
+
+            if (edition != null)
+            {
+                CompDB? compDB = GetEditionCompDBForLanguage(CompositionDatabases, edition, LanguageCode);
+
+                if (compDB != null)
+                {
+                    foreach (Package feature in compDB.Features.Feature[0].Packages.Package)
+                    {
+                        Package pkg = compDB.Packages.Package.First(x => x.ID == feature.ID);
+
+                        string file = pkg.GetCommonlyUsedIncorrectFileName();
+
+                        if (feature.PackageType == "MetadataESD")
+                        {
+                            if (!File.Exists(Path.Combine(UUPPath, file)))
+                            {
+                                file = pkg.Payload.PayloadItem[0].Path.Replace('\\', Path.DirectorySeparatorChar);
+                                if (!File.Exists(Path.Combine(UUPPath, file)))
+                                {
+                                    break;
+                                }
+                            }
+
+                            return (true, Path.Combine(UUPPath, file));
+                        }
+                    }
+                }
+            }
 
             HashSet<CompDB> filteredCompositionDatabases = CompositionDatabases.GetEditionCompDBsForLanguage(LanguageCode);
             if (filteredCompositionDatabases.Count > 0)

--- a/src/UnifiedUpdatePlatform.Media.Creator/Installer/SetupMediaCreator.cs
+++ b/src/UnifiedUpdatePlatform.Media.Creator/Installer/SetupMediaCreator.cs
@@ -37,12 +37,13 @@ namespace UnifiedUpdatePlatform.Media.Creator.Installer
             Common.Messaging.Common.CompressionType CompressionType,
             IEnumerable<CompDB> CompositionDatabases,
             TempManager tempManager,
-            ProgressCallback progressCallback = null)
+            ProgressCallback progressCallback = null,
+            string edition = null)
         {
             bool result = true;
             string BaseESD = null;
 
-            (result, BaseESD) = FileLocator.LocateFilesForSetupMediaCreation(UUPPath, LanguageCode, CompositionDatabases, progressCallback);
+            (result, BaseESD) = FileLocator.LocateFilesForSetupMediaCreation(UUPPath, LanguageCode, CompositionDatabases, progressCallback, edition: edition);
             if (!result)
             {
                 goto exit;

--- a/src/UnifiedUpdatePlatform.Media.Creator/MediaCreator.cs
+++ b/src/UnifiedUpdatePlatform.Media.Creator/MediaCreator.cs
@@ -419,7 +419,7 @@ namespace UnifiedUpdatePlatform.Media.Creator
                 //
                 // Build installer
                 //
-                result = SetupMediaCreator.CreateSetupMedia(UUPPath, LanguageCode, MediaRootPath, WinREWIMFilePath, CompressionType, CompositionDatabases, tempManager, progressCallback);
+                result = SetupMediaCreator.CreateSetupMedia(UUPPath, LanguageCode, MediaRootPath, WinREWIMFilePath, CompressionType, CompositionDatabases, tempManager, progressCallback: progressCallback, edition: Edition);
                 if (!result)
                 {
                     error = "An error occurred while creating setup media.";


### PR DESCRIPTION
Added an edition parameter to ensure the process uses a matching Base Edition when creating setup media if possible.

The lack of edition filtering could lead to an incorrect product.ini and other potential problems.